### PR TITLE
pound comments could cause parser to choke.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,9 @@ var parse = module.exports = function(input) {
     .split("\n")
     .forEach(function(line) {
       var parts = line.split(/:(.+)?/) // split on _first_ colon
+
+      if (parts.length < 2) return
+
       var key = parts[0].trim()
       var value = parts[1].trim()
 

--- a/test/fixtures/pound_comments.html
+++ b/test/fixtures/pound_comments.html
@@ -1,0 +1,4 @@
+<!--
+# Copyright (c) 2012 Ben Coe
+-->
+<h1>Hello World</h1>

--- a/test/index.js
+++ b/test/index.js
@@ -61,4 +61,10 @@ describe("html-frontmatter", function() {
     assert(fm.pattern)
   })
 
+  // Regressions
+
+  it("handles HTML comments that contain the pound symbol", function() {
+    assert.deepEqual(fm(fixtures.pound_comments), {})
+  })
+
 })


### PR DESCRIPTION
Having comments of this form:

```html
<!--
# Copyright (c) 2012 Ben Coe
-->
```

could cause the parser to raise an exception.