### PR TITLE
Bug: including additional comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var path = require("path")
 var fs = require("fs")
 var fmt = require("util").format
-var pattern = new RegExp("^\n*<!--\n?([^]*)\n?-->")
+var pattern = new RegExp("^\n*<!--([^]*?)-->")
 
 var parse = module.exports = function(input) {
 

--- a/test/fixtures/multi_comment.html
+++ b/test/fixtures/multi_comment.html
@@ -1,0 +1,9 @@
+<!--
+foo: bar
+-->
+
+<h1>Watch out for other comments</h1>
+
+<!--
+  unrelated_comment: quit your jibber jabber
+-->

--- a/test/index.js
+++ b/test/index.js
@@ -49,6 +49,10 @@ describe("html-frontmatter", function() {
     assert.deepEqual(fm(fixtures.single_line), {foo: "bar"})
   })
 
+  it("does not include additional comments", function(){
+    assert.deepEqual(fm(fixtures.multi_comment), { foo: "bar" })
+  })
+
   // Coercion
 
   it("coerces boolean strings into booleans", function(){


### PR DESCRIPTION
I've added a test for this bug...  

```
it("does not include additional comments", function(){
  assert.deepEqual(fm(fixtures.multi_comment), { foo: "bar" })
})
```
__Failing result:__
```
14 passing (18ms)
  1 failing

  1) html-frontmatter does not include additional comments:
     AssertionError: {"foo":"bar","<!-- unrelated_comment":"quit your jibber jabber"} deepEqual {"foo":"bar"}
```

__Solution:__  Tidied up the regex lazy matching, and removed some extra newline refs, as they're already covered by `[^]` 