### PR TITLE
Changes in RegEx patterns to correct issue #12

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const dateutil = require('dateutil')
-const pattern = new RegExp('^\n*<!--([^]*?)-->') // eslint-disable-line
+const pattern = new RegExp('^(?:\r\n?|\n)*<!--([^]*?)-->') // eslint-disable-line
 
 const parse = module.exports = function parse (input) {
   if (!input.match(pattern)) return
@@ -10,9 +10,9 @@ const parse = module.exports = function parse (input) {
 
   pattern
     .exec(input)[1]
-    .replace(/\n{2,}/g, '\n') // remove excess newlines
-    .replace(/\n\s{2,}/g, ' ') // treat two-space indentation as a wrapped line
-    .replace(/\s{2,}/g, ' ') // remove excess spaces
+    .replace(/(\r\n?|\n){2,}/g, '\n') // remove excess newlines
+    .replace(/(\r\n?|\n) {2,}/g, ' ') // treat two-space indentation as a wrapped line
+//    .replace(/[ \t]{2,}/g, ' ') // remove excess spaces or tabs (but no new lines)
     .split('\n')
     .forEach(function (line) {
       if (line.match(/^\s?#/)) return // ignore lines starting with #

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/zeke/html-frontmatter",
   "devDependencies": {
-    "mocha": "^1.21.4",
+    "mocha": "^3.2.0",
     "standard": "^7.1.0"
   },
   "dependencies": {


### PR DESCRIPTION
I updated Mocha first (to get rid of a deprecation warning).
Found out that extra white spaces is not a real problem. I think Javascript takes care of stripping leading and trailing spaces.
The problem was that the RegEx special character `\s` matches a single white space character, including space, tab, form feed, and **line feed**. The problem was erasing the LF
A better approach could have been to look for 2 or more space characters or tab characters but it was not necessary (so that is commented out in the code).
An underlying problem was the Windows newlines made of CR + LF instead of just LF characters.
All test passing.